### PR TITLE
set instalattion method on load

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,4 +30,6 @@ window._refiner = function() {
   _refinerQueue.push(arguments);
 }
 
+window._refiner('setInstallationMethod', 'npm');
+
 module.exports = window._refiner;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "refiner-js",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Official NPM wrapper for the Refiner.io JavaScript client",
   "main": "index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
# What it does
This pull request adds a method call to "setInstallationMethod" which allows the support staff of Refiner to quickly identify "npm" as installation method for the web-client.

# How to test it

1. load the refiner-js package as usual
2. activate debug mode

# Acceptance criteria

* The debug panel shows the installation method "npm"

