### PR TITLE
feat/fix: add return to load-promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,11 @@ function loadRefinerClient() {
       resolve();
     }
 
-    script.onerror = function() {
-      reject(new Error('Could not load Refiner client.'));
+    script.onerror = function(event) {
+        const errorDetails = event && event.target ?
+            `URL: ${event.target.src}, Type: ${event.type}` :
+            'Unknown error';
+        reject(new Error(`Could not load Refiner client. ${errorDetails}`));
     }
 
     document.head.appendChild(script);

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict';
 
-let clientAlreadyLoaded = false;
+let refinerClientAlreadyLoaded = false;
 
 function loadRefinerClient() {
-  clientAlreadyLoaded = true;
-  new Promise(function(resolve, reject) {
+  refinerClientAlreadyLoaded = true;
+  return new Promise(function(resolve, reject) {
 
     const script = document.createElement('script');
     script.src = 'https://js.refiner.io/v001/client.js';
@@ -24,10 +24,12 @@ function loadRefinerClient() {
 
 window._refinerQueue = window._refinerQueue || [];
 window._refiner = function() {
-  if (!clientAlreadyLoaded) {
-      loadRefinerClient();
+  let loadPromise = Promise.resolve();
+  if (!refinerClientAlreadyLoaded) {
+      loadPromise = loadRefinerClient();
   }
   _refinerQueue.push(arguments);
+  return loadPromise;
 }
 
 window._refiner('setInstallationMethod', 'npm');

--- a/readme.md
+++ b/readme.md
@@ -19,9 +19,9 @@ Copy & paste the code below into your applications and replace the static value 
 That's it! The Refiner JavaScript is now loaded and communicating with the Refiner API.
 
 ```js
-import _refiner from 'refiner-js';
+import Refiner from 'refiner-js';
 
-_refiner('setProject', 'REFINER_PROJECT_ID');
+Refiner('setProject', 'REFINER_PROJECT_ID');
 ```
 
 ### Identify your users (recommended)
@@ -33,7 +33,7 @@ Identifying your users allows you to better target specific accounts, sync surve
 Identifying a user is easy with our Javascript client. All you need to do is to call a identifyUser method once our Javasript client was loaded.
 
 ```js
-_refiner('identifyUser', {
+Refiner('identifyUser', {
   id: 'USER-ID-ABC-123', // Each user needs an ID or email address
   email: 'jane@awesome.com', // Each user needs an ID or email address
   name: 'Jane Doe', // The full name of the user

--- a/readme.md
+++ b/readme.md
@@ -19,9 +19,9 @@ Copy & paste the code below into your applications and replace the static value 
 That's it! The Refiner JavaScript is now loaded and communicating with the Refiner API.
 
 ```js
-import Refiner from 'refiner-js';
+import _refiner from 'refiner-js';
 
-Refiner('setProject', 'REFINER_PROJECT_ID');
+_refiner('setProject', 'REFINER_PROJECT_ID');
 ```
 
 ### Identify your users (recommended)
@@ -33,7 +33,7 @@ Identifying your users allows you to better target specific accounts, sync surve
 Identifying a user is easy with our Javascript client. All you need to do is to call a identifyUser method once our Javasript client was loaded.
 
 ```js
-Refiner('identifyUser', {
+_refiner('identifyUser', {
   id: 'USER-ID-ABC-123', // Each user needs an ID or email address
   email: 'jane@awesome.com', // Each user needs an ID or email address
   name: 'Jane Doe', // The full name of the user


### PR DESCRIPTION
# What it does
This pull requests exposes the script loading process as a Promise-based API. It allows consumers to properly handle the loading the Refiner script, enabling better error handling and sequential operations.

**Important:** Before merging, test the code and check if all acceptance criteria are fulfilled as described below. Then, add a comment "Reviewed & tested" to this pull request.

# How to test it

1. Install / load script from this branch or overwrite index manually
2. Wrap your `_refiner` functions like `setProject` in a try/catch
3. Provoking a breaking load, e.g. changing the API URL to intentionally not load
4. Using the try/catch as below, we should now be able to handle cases where the script failed to load from within our app

# Acceptance criteria

* The script still loads and shows surveys as expected
* The promise is returned properly, so app-level try/catch either follows the success or error case

# Example usage
```
window._refiner('setProject', 'project-id')
  .then(() => {
    console.log('Refiner script loaded successfully');
    // Continue with operations that depend on Refiner being loaded
  })
  .catch(error => {
    console.error('Failed to load Refiner:', error);
    // Handle the error appropriately
  });
```

# Link to ticket

Fixes https://github.com/refiner-io/js-client-npm/issues/15
